### PR TITLE
Fix: Set value at the top level

### DIFF
--- a/src/Controller.test.tsx
+++ b/src/Controller.test.tsx
@@ -4,7 +4,13 @@ import { render, queries, fireEvent } from "@testing-library/react";
 import { Controller } from "./Controller";
 import { useController } from "./useController";
 
-const TestComponent: React.FC = () => {
+function TestComponent({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  renderTracker = () => {},
+}: {
+  renderTracker?: () => void;
+}) {
+  renderTracker();
   const control = useController({ a: { b: [1] } });
   return (
     <Controller<{ a: { b: number[] } }, number>
@@ -19,7 +25,7 @@ const TestComponent: React.FC = () => {
       )}
     />
   );
-};
+}
 
 test("should render with correct value", async () => {
   const { getByTestId } = render(<TestComponent />, { queries });
@@ -32,4 +38,15 @@ test("should change the vlaue correctly", () => {
   const input = getByTestId("rendered-input") as HTMLInputElement;
   fireEvent.change(input, { target: { value: 123 } });
   expect(input.value).toBe("123");
+});
+
+test("no rerender when onChange trigger", () => {
+  const renderTracker = jest.fn();
+  const { getByTestId } = render(
+    <TestComponent renderTracker={renderTracker} />,
+    { queries }
+  );
+  const input = getByTestId("rendered-input") as HTMLInputElement;
+  fireEvent.change(input, { target: { value: 123 } });
+  expect(renderTracker).toBeCalledTimes(1);
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -29,31 +29,31 @@ describe("setValueByPath", () => {
   it("set all value should work correctly", () => {
     const obj = { a: 1, b: 2, c: 3 };
     const array = [1, 2, 3, 4];
-    const resultObj = setValueByPath(obj, undefined, { a: 11, b: 22 });
+    const resultObj = setValueByPath(obj, { a: 11, b: 22 });
     expect(resultObj).toEqual({ a: 11, b: 22 });
-    const resultArr = setValueByPath(array, undefined, [7, 8, 9]);
+    const resultArr = setValueByPath(array, [7, 8, 9]);
     expect(resultArr).toEqual([7, 8, 9]);
   });
 
   it("should set correct value to first level", () => {
     const obj = { a: 1, b: 2, c: 3 };
     const array = [1, 2, 3, 4];
-    const resultObj = setValueByPath(obj, "a", 10);
+    const resultObj = setValueByPath(obj, 10, "a");
     expect(resultObj.a).toBe(10);
-    const resultArr = setValueByPath(array, "2", 10);
+    const resultArr = setValueByPath(array, 10, "2");
     expect(resultArr[2]).toBe(10);
   });
 
   it("should set correct value to nested level", () => {
     const obj = { a: { a1: 1, a2: 2 }, c: [3, 4, 5] };
     const array = [null, { a: { a1: 1, a2: 2 }, c: [3, 4, 5] }];
-    const resultObj1 = setValueByPath(obj, "a.a2", 10);
+    const resultObj1 = setValueByPath(obj, 10, "a.a2");
     expect(resultObj1.a.a2).toBe(10);
-    const resultObj2 = setValueByPath(obj, "c[1]", 10);
+    const resultObj2 = setValueByPath(obj, 10, "c[1]");
     expect(resultObj2.c[1]).toBe(10);
-    const resultArr1 = setValueByPath(array, "[1].a.a2", -1);
+    const resultArr1 = setValueByPath(array, -1, "[1].a.a2");
     expect(resultArr1[1]?.a.a2).toBe(-1);
-    const resultArr2 = setValueByPath(array, "[1].c[2]", -2);
+    const resultArr2 = setValueByPath(array, -2, "[1].c[2]");
     expect(resultArr2[1]?.c[2]).toBe(-2);
   });
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -26,25 +26,34 @@ describe("getValueByPath", () => {
 });
 
 describe("setValueByPath", () => {
+  it("set all value should work correctly", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const array = [1, 2, 3, 4];
+    const resultObj = setValueByPath(obj, undefined, { a: 11, b: 22 });
+    expect(resultObj).toEqual({ a: 11, b: 22 });
+    const resultArr = setValueByPath(array, undefined, [7, 8, 9]);
+    expect(resultArr).toEqual([7, 8, 9]);
+  });
+
   it("should set correct value to first level", () => {
     const obj = { a: 1, b: 2, c: 3 };
     const array = [1, 2, 3, 4];
-    setValueByPath(obj, "a", 10);
-    expect(obj.a).toBe(10);
-    setValueByPath(array, "2", 10);
-    expect(array[2]).toBe(10);
+    const resultObj = setValueByPath(obj, "a", 10);
+    expect(resultObj.a).toBe(10);
+    const resultArr = setValueByPath(array, "2", 10);
+    expect(resultArr[2]).toBe(10);
   });
 
   it("should set correct value to nested level", () => {
     const obj = { a: { a1: 1, a2: 2 }, c: [3, 4, 5] };
     const array = [null, { a: { a1: 1, a2: 2 }, c: [3, 4, 5] }];
-    setValueByPath(obj, "a.a2", 10);
-    expect(obj.a.a2).toBe(10);
-    setValueByPath(obj, "c[1]", 10);
-    expect(obj.c[1]).toBe(10);
-    setValueByPath(array, "[1].a.a2", -1);
-    expect(array[1]?.a.a2).toBe(-1);
-    setValueByPath(array, "[1].c[2]", -2);
-    expect(array[1]?.c[2]).toBe(-2);
+    const resultObj1 = setValueByPath(obj, "a.a2", 10);
+    expect(resultObj1.a.a2).toBe(10);
+    const resultObj2 = setValueByPath(obj, "c[1]", 10);
+    expect(resultObj2.c[1]).toBe(10);
+    const resultArr1 = setValueByPath(array, "[1].a.a2", -1);
+    expect(resultArr1[1]?.a.a2).toBe(-1);
+    const resultArr2 = setValueByPath(array, "[1].c[2]", -2);
+    expect(resultArr2[1]?.c[2]).toBe(-2);
   });
 });

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -9,7 +9,8 @@ export function getValueByPath<T>(obj: any, path = ""): T {
     }, obj);
 }
 
-export function setValueByPath<T>(obj: any, path = "", newVal: T): void {
+export function setValueByPath<T>(obj: any, path = "", newVal: T): any {
+  if (path === "") return newVal;
   const pathInArr = path
     .replace(/\[(\w+)\]/g, ".$1") // convert indexes to properties
     .replace(/^\./, "") // strip a leading dot
@@ -20,4 +21,5 @@ export function setValueByPath<T>(obj: any, path = "", newVal: T): void {
     return acc;
   }, obj);
   theRef[pathInArr[pathInArr.length - 1]] = newVal;
+  return obj;
 }

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -9,7 +9,7 @@ export function getValueByPath<T>(obj: any, path = ""): T {
     }, obj);
 }
 
-export function setValueByPath<T>(obj: any, path = "", newVal: T): any {
+export function setValueByPath<T>(obj: any, newVal: T, path = ""): any {
   if (path === "") return newVal;
   const pathInArr = path
     .replace(/\[(\w+)\]/g, ".$1") // convert indexes to properties

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -14,7 +14,7 @@ function useController<U>(initialState: U): ControlType<U> {
     listeners.current.push(cb);
   }, []);
   const updateValue = useCallback(<Type>(path: string, value: Type): void => {
-    setValueByPath(state.current, path, value);
+    state.current = setValueByPath(state.current, path, value);
     listeners.current.forEach((cb) => {
       cb(state.current);
     });

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -14,7 +14,7 @@ function useController<U>(initialState: U): ControlType<U> {
     listeners.current.push(cb);
   }, []);
   const updateValue = useCallback(<Type>(path: string, value: Type): void => {
-    state.current = setValueByPath(state.current, path, value);
+    state.current = setValueByPath(state.current, value, path);
     listeners.current.forEach((cb) => {
       cb(state.current);
     });


### PR DESCRIPTION
* Handle the case if we set value at the top level (without passing `path` to the `setValueByPath`).
* Move the optional parameter `path` to the last